### PR TITLE
Doorkeeperに公開中のイベント情報を教えてくれるコマンドを追加

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+  timezone:
+    Asia/Tokyo

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "highwide <hochweit728@gmail.com>",
   "description": "Princess of Yochiyochi.rb",
   "dependencies": {
+    "bluebird": "^2.10.0",
     "hubot": "^2.12.0",
     "hubot-diagnostics": "0.0.1",
     "hubot-google-images": "^0.1.4",

--- a/package.json
+++ b/package.json
@@ -23,5 +23,15 @@
   },
   "engines": {
     "node": "0.10.x"
+  },
+  "devDependencies": {
+    "chai": "^3.2.0",
+    "coffee-script": "^1.10.0",
+    "hubot-test-helper": "0.0.7",
+    "mocha": "^2.3.2",
+    "nock": "^2.10.0"
+  },
+  "scripts": {
+    "test": "mocha --compilers coffee:coffee-script/register test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "hubot-rules": "^0.1.0",
     "hubot-scripts": "^2.5.16",
     "hubot-shipit": "^0.2.0",
-    "hubot-youtube": "^0.1.2"
+    "hubot-youtube": "^0.1.2",
+    "request-promise": "^0.4.3"
   },
   "engines": {
     "node": "0.10.x"

--- a/scripts/events.coffee
+++ b/scripts/events.coffee
@@ -1,0 +1,59 @@
+# Description:
+#   Tells yochiyochi.rb's published events on Doorkeeper
+#
+# Commands:
+#   hubot event(s) - Tells published events for yochiyochi.rb
+
+class Event
+  constructor: (args) ->
+    @title = args.title
+    @starts_at = Event.formatDate(args.starts_at)
+    @ends_at = Event.formatDate(args.ends_at)
+    @venue_name = args.venue_name
+    @url = args.public_url
+
+  @formatDate: (dateString) ->
+    toDouble = (num) ->
+      num += ""
+      num = "0" + num if num.length == 1
+      num
+    date = new Date(dateString)
+    "#{date.getFullYear()}年#{toDouble(date.getMonth())}月#{toDouble(date.getDate())}日" +
+    " #{toDouble(date.getHours())}:#{toDouble(date.getMinutes())}"
+
+  @parse: (body) ->
+    content = ""
+    data = JSON.parse(body)
+    if data.length
+      for item in data
+        event = new Event(item.event)
+        content += event.response() + "\n"
+    else
+      content += "公開中のイベントはありません :ghost:\n"
+    content
+
+  response: ->
+    [
+      ":star2: #{@title}",
+      ":calendar: #{@starts_at}",
+      ":earth_asia: #{@venue_name}",
+      @url,
+      ""
+    ].join("\n")
+
+module.exports = (robot) ->
+  robot.respond /events?/i, (msg) ->
+    response = ":hatching_chick: :baby_chick: よちよち.rb の公開中のイベント :hatching_chick: :baby_chick:\n\n"
+    rp = require('request-promise')
+    rp("http://api.doorkeeper.jp/groups/yochiyochirb/events")
+    .then (body) ->
+      response += Event.parse(body)
+      response += "\n:beers: :beer: よちよち.beer の公開中のイベント :beers: :beer:\n\n"
+      rp("http://api.doorkeeper.jp/groups/yochiyochibeer/events")
+      .then (body) ->
+        response += Event.parse(body)
+        msg.send response
+      .catch ->
+        msg.send "データ取得エラー :cry:\n"
+    .catch ->
+      msg.send "データ取得エラー :cry:\n"

--- a/scripts/events.coffee
+++ b/scripts/events.coffee
@@ -46,7 +46,7 @@ class Event
     ].join("\n")
 
 module.exports = (robot) ->
-  robot.respond /events?/i, (msg) ->
+  robot.respond /events?$/i, (msg) ->
     response = ":hatching_chick: :baby_chick: よちよち.rb の公開中のイベント :hatching_chick: :baby_chick:\n\n"
     rp = require('request-promise')
     rp("http://api.doorkeeper.jp/groups/yochiyochirb/events")

--- a/scripts/events.coffee
+++ b/scripts/events.coffee
@@ -10,6 +10,9 @@ class Event
     @starts_at = Event.formatDate(args.starts_at)
     @ends_at = Event.formatDate(args.ends_at)
     @venue_name = args.venue_name
+    @ticket_limit = args.ticket_limit
+    @participants = args.participants
+    @waitlisted = args.waitlisted
     @url = args.public_url
 
   @formatDate: (dateString) ->
@@ -37,6 +40,7 @@ class Event
       ":star2: #{@title}",
       ":calendar: #{@starts_at}",
       ":earth_asia: #{@venue_name}",
+      # ":couple: #{@participants}/#{@ticket_limit} (キャンセル待ち #{@waitlisted}人)",
       @url,
       ""
     ].join("\n")
@@ -54,6 +58,6 @@ module.exports = (robot) ->
         response += Event.parse(body)
         msg.send response
       .catch ->
-        msg.send "データ取得エラー :cry:\n"
+        msg.send "データ取得エラー (yochiyochibeer) :cry:\n"
     .catch ->
-      msg.send "データ取得エラー :cry:\n"
+      msg.send "データ取得エラー (yochiyochirb) :cry:\n"

--- a/scripts/events.coffee
+++ b/scripts/events.coffee
@@ -54,7 +54,7 @@ class Event
       ":star2: #{@title}",
       ":calendar: #{@starts_at}",
       ":earth_asia: #{@venue_name}",
-      # ":couple: #{@participants}/#{@ticket_limit} (キャンセル待ち #{@waitlisted}人)",
+      ":couple: #{@participants}/#{@ticket_limit} (キャンセル待ち #{@waitlisted}人)",
       @url,
       ""
     ].join("\n")

--- a/scripts/events.coffee
+++ b/scripts/events.coffee
@@ -13,13 +13,13 @@ class Event
     @url = args.public_url
 
   @formatDate: (dateString) ->
-    toDouble = (num) ->
+    zeroPadding = (num) ->
       num += ""
       num = "0" + num if num.length == 1
       num
     date = new Date(dateString)
-    "#{date.getFullYear()}年#{toDouble(date.getMonth())}月#{toDouble(date.getDate())}日" +
-    " #{toDouble(date.getHours())}:#{toDouble(date.getMinutes())}"
+    "#{date.getFullYear()}年#{zeroPadding(date.getMonth())}月#{zeroPadding(date.getDate())}日" +
+    " #{zeroPadding(date.getHours())}:#{zeroPadding(date.getMinutes())}"
 
   @parse: (body) ->
     content = ""

--- a/scripts/events.coffee
+++ b/scripts/events.coffee
@@ -31,9 +31,7 @@ class Event
 
   @formatDate: (dateString) ->
     zeroPadding = (num) ->
-      num += ""
-      num = "0" + num if num.length == 1
-      num
+      ("0" + num).slice(-2)
     date = new Date(dateString)
     "#{date.getFullYear()}年#{zeroPadding(date.getMonth() + 1)}月#{zeroPadding(date.getDate())}日" +
     " #{zeroPadding(date.getHours())}:#{zeroPadding(date.getMinutes())}"

--- a/scripts/events.coffee
+++ b/scripts/events.coffee
@@ -18,7 +18,7 @@ class Event
       num = "0" + num if num.length == 1
       num
     date = new Date(dateString)
-    "#{date.getFullYear()}年#{zeroPadding(date.getMonth())}月#{zeroPadding(date.getDate())}日" +
+    "#{date.getFullYear()}年#{zeroPadding(date.getMonth() + 1)}月#{zeroPadding(date.getDate())}日" +
     " #{zeroPadding(date.getHours())}:#{zeroPadding(date.getMinutes())}"
 
   @parse: (body) ->

--- a/test/events_test.coffee
+++ b/test/events_test.coffee
@@ -93,7 +93,7 @@ describe 'events', ->
         ['alice', 'hubot events']
         [
           'hubot',
-          ":hatching_chick: :baby_chick: よちよち.rb の公開中のイベント :hatching_chick: :baby_chick:\n\n:star2: よちよちスーパーもくもく会 第xx回\n:calendar: 2015年09月19日 14:00\n:earth_asia: 合同会社yochiyochi\nhttps://yochiyochirb.doorkeeper.jp/events/xxxxx\n\n\n:beers: :beer: よちよち.beer の公開中のイベント :beers: :beer:\n\n:star2: よちよち.beer 第xx回\n:calendar: 2015年09月14日 20:00\n:earth_asia: バーよちよち\nhttps://yochiyochirb.doorkeeper.jp/events/xxxxx\n\n"
+          ":hatching_chick: :baby_chick: よちよち.rb の公開中のイベント :hatching_chick: :baby_chick:\n\n:star2: よちよちスーパーもくもく会 第xx回\n:calendar: 2015年09月19日 14:00\n:earth_asia: 合同会社yochiyochi\n:couple: 15/20 (キャンセル待ち 0人)\nhttps://yochiyochirb.doorkeeper.jp/events/xxxxx\n\n\n:beers: :beer: よちよち.beer の公開中のイベント :beers: :beer:\n\n:star2: よちよち.beer 第xx回\n:calendar: 2015年09月14日 20:00\n:earth_asia: バーよちよち\n:couple: 10/15 (キャンセル待ち 0人)\nhttps://yochiyochirb.doorkeeper.jp/events/xxxxx\n\n"
         ]
       ]
 
@@ -112,7 +112,7 @@ describe 'events', ->
         ['alice', 'hubot event']
         [
           'hubot',
-          ":hatching_chick: :baby_chick: よちよち.rb の公開中のイベント :hatching_chick: :baby_chick:\n\n:star2: よちよちスーパーもくもく会 第xx回\n:calendar: 2015年09月19日 14:00\n:earth_asia: 合同会社yochiyochi\nhttps://yochiyochirb.doorkeeper.jp/events/xxxxx\n\n\n:beers: :beer: よちよち.beer の公開中のイベント :beers: :beer:\n\n:star2: よちよち.beer 第xx回\n:calendar: 2015年09月14日 20:00\n:earth_asia: バーよちよち\nhttps://yochiyochirb.doorkeeper.jp/events/xxxxx\n\n"
+          ":hatching_chick: :baby_chick: よちよち.rb の公開中のイベント :hatching_chick: :baby_chick:\n\n:star2: よちよちスーパーもくもく会 第xx回\n:calendar: 2015年09月19日 14:00\n:earth_asia: 合同会社yochiyochi\n:couple: 15/20 (キャンセル待ち 0人)\nhttps://yochiyochirb.doorkeeper.jp/events/xxxxx\n\n\n:beers: :beer: よちよち.beer の公開中のイベント :beers: :beer:\n\n:star2: よちよち.beer 第xx回\n:calendar: 2015年09月14日 20:00\n:earth_asia: バーよちよち\n:couple: 10/15 (キャンセル待ち 0人)\nhttps://yochiyochirb.doorkeeper.jp/events/xxxxx\n\n"
         ]
       ]
 

--- a/test/events_test.coffee
+++ b/test/events_test.coffee
@@ -150,7 +150,7 @@ describe 'events', ->
         ['alice', 'hubot events']
         [
           'hubot',
-          "データ取得エラー (yochiyochirb) :cry:\n"
+          "データ取得エラー :cry:\n"
         ]
       ]
 
@@ -169,6 +169,6 @@ describe 'events', ->
         ['alice', 'hubot events']
         [
           'hubot',
-          "データ取得エラー (yochiyochibeer) :cry:\n"
+          "データ取得エラー :cry:\n"
         ]
       ]

--- a/test/events_test.coffee
+++ b/test/events_test.coffee
@@ -1,0 +1,174 @@
+Helper = require('hubot-test-helper')
+expect = require('chai').expect
+nock = require('nock')
+
+helper = new Helper('./../scripts/events.coffee')
+
+yochiyochirbResponse = [
+  {
+    event: {
+      title: "よちよち.rb 第xx回",
+      id: 65535,
+      starts_at: "2015-09-14T11:00:00.000Z",
+      ends_at: "2015-09-14T13:00:00.000Z",
+      venue_name: "株式会社よちよち",
+      address: "東京都渋谷区xxxxx",
+      lat: null,
+      long: null,
+      ticket_limit: 15,
+      published_at: "2015-09-09T04:32:05.292Z",
+      updated_at: "2015-09-10T16:01:28.959Z",
+      group: 2203,
+      description: "p",
+      public_url: "https://yochiyochirb.doorkeeper.jp/events/xxxxx",
+      participants: 9,
+      waitlisted: 0
+    },
+    event: {
+      title: "よちよちスーパーもくもく会 第xx回",
+      id: 65536,
+      starts_at: "2015-09-19T05:00:00.000Z",
+      ends_at: "2015-09-19T10:00:00.000Z",
+      venue_name: "合同会社yochiyochi",
+      address: "東京都品川区xxxxx",
+      lat: null,
+      long: null,
+      ticket_limit: 20,
+      published_at: "2015-09-09T04:32:05.292Z",
+      updated_at: "2015-09-10T16:01:28.959Z",
+      group: 2203,
+      description: "p",
+      public_url: "https://yochiyochirb.doorkeeper.jp/events/xxxxx",
+      participants: 15,
+      waitlisted: 0
+    }
+  }
+]
+
+yochiyochibeerResponse = [
+  {
+    event: {
+      title: "よちよち.beer 第xx回",
+      id: 65537,
+      starts_at: "2015-09-14T11:00:00.000Z",
+      ends_at: "2015-09-14T13:00:00.000Z",
+      venue_name: "バーよちよち",
+      address: "東京都新宿区xxxxx",
+      lat: null,
+      long: null,
+      ticket_limit: 15,
+      published_at: "2015-09-09T04:32:05.292Z",
+      updated_at: "2015-09-10T16:01:28.959Z",
+      group: 2204,
+      description: "p",
+      public_url: "https://yochiyochirb.doorkeeper.jp/events/xxxxx",
+      participants: 10,
+      waitlisted: 0
+    }
+  }
+]
+
+describe 'events', ->
+
+  beforeEach ->
+    @room = helper.createRoom()
+    do nock.disableNetConnect
+
+  afterEach ->
+    @room.destroy()
+    nock.cleanAll()
+
+  context 'user says "events" and both yochiyochirb and yochiyochibeer events are available', ->
+    beforeEach (done) ->
+      nock('http://api.doorkeeper.jp/')
+        .get('/groups/yochiyochirb/events')
+        .reply 200, yochiyochirbResponse
+        .get('/groups/yochiyochibeer/events')
+        .reply 200, yochiyochibeerResponse
+      @room.user.say 'alice', 'hubot events'
+      setTimeout done, 100
+
+    it 'should tell published events to user', ->
+      expect(@room.messages).to.eql [
+        ['alice', 'hubot events']
+        [
+          'hubot',
+          ":hatching_chick: :baby_chick: よちよち.rb の公開中のイベント :hatching_chick: :baby_chick:\n\n:star2: よちよちスーパーもくもく会 第xx回\n:calendar: 2015年09月19日 14:00\n:earth_asia: 合同会社yochiyochi\nhttps://yochiyochirb.doorkeeper.jp/events/xxxxx\n\n\n:beers: :beer: よちよち.beer の公開中のイベント :beers: :beer:\n\n:star2: よちよち.beer 第xx回\n:calendar: 2015年09月14日 20:00\n:earth_asia: バーよちよち\nhttps://yochiyochirb.doorkeeper.jp/events/xxxxx\n\n"
+        ]
+      ]
+
+  context 'user says "event" and both yochiyochirb and yochiyochibeer events are available', ->
+    beforeEach (done) ->
+      nock('http://api.doorkeeper.jp/')
+        .get('/groups/yochiyochirb/events')
+        .reply 200, yochiyochirbResponse
+        .get('/groups/yochiyochibeer/events')
+        .reply 200, yochiyochibeerResponse
+      @room.user.say 'alice', 'hubot event'
+      setTimeout done, 100
+
+    it 'should tell published events to user', ->
+      expect(@room.messages).to.eql [
+        ['alice', 'hubot event']
+        [
+          'hubot',
+          ":hatching_chick: :baby_chick: よちよち.rb の公開中のイベント :hatching_chick: :baby_chick:\n\n:star2: よちよちスーパーもくもく会 第xx回\n:calendar: 2015年09月19日 14:00\n:earth_asia: 合同会社yochiyochi\nhttps://yochiyochirb.doorkeeper.jp/events/xxxxx\n\n\n:beers: :beer: よちよち.beer の公開中のイベント :beers: :beer:\n\n:star2: よちよち.beer 第xx回\n:calendar: 2015年09月14日 20:00\n:earth_asia: バーよちよち\nhttps://yochiyochirb.doorkeeper.jp/events/xxxxx\n\n"
+        ]
+      ]
+
+  context 'user says "events" and both yochiyochirb and yochiyochibeer events are available but empty', ->
+    beforeEach (done) ->
+      nock('http://api.doorkeeper.jp/')
+        .get('/groups/yochiyochirb/events')
+        .reply 200, []
+        .get('/groups/yochiyochibeer/events')
+        .reply 200, []
+      @room.user.say 'alice', 'hubot events'
+      setTimeout done, 100
+
+    it 'should tell published events to user', ->
+      expect(@room.messages).to.eql [
+        ['alice', 'hubot events']
+        [
+          'hubot',
+          ":hatching_chick: :baby_chick: よちよち.rb の公開中のイベント :hatching_chick: :baby_chick:\n\n公開中のイベントはありません :ghost:\n\n:beers: :beer: よちよち.beer の公開中のイベント :beers: :beer:\n\n公開中のイベントはありません :ghost:\n"
+        ]
+      ]
+
+  context 'user says "events" and fails to get yochiyochirb events', ->
+    beforeEach (done) ->
+      nock('http://api.doorkeeper.jp/')
+        .get('/groups/yochiyochirb/events')
+        .reply 404, []
+        .get('/groups/yochiyochibeer/events')
+        .reply 200, []
+      @room.user.say 'alice', 'hubot events'
+      setTimeout done, 100
+
+    it 'should tell published events to user', ->
+      expect(@room.messages).to.eql [
+        ['alice', 'hubot events']
+        [
+          'hubot',
+          "データ取得エラー (yochiyochirb) :cry:\n"
+        ]
+      ]
+
+  context 'user says "events" and fails to get yochiyochibeer events', ->
+    beforeEach (done) ->
+      nock('http://api.doorkeeper.jp/')
+        .get('/groups/yochiyochirb/events')
+        .reply 200, []
+        .get('/groups/yochiyochibeer/events')
+        .reply 403, []
+      @room.user.say 'alice', 'hubot events'
+      setTimeout done, 100
+
+    it 'should tell published events to user', ->
+      expect(@room.messages).to.eql [
+        ['alice', 'hubot events']
+        [
+          'hubot',
+          "データ取得エラー (yochiyochibeer) :cry:\n"
+        ]
+      ]


### PR DESCRIPTION
Doorkeeperに公開中の「よちよち.rb」と「よちよち.beer」の情報を教えてくれる `events` コマンドを作りました。s を忘れて `event` でも実行できます。

<img width="659" alt="ssss" src="https://cloud.githubusercontent.com/assets/333180/9795470/d784e6e8-582b-11e5-891f-a6087b50088a.png">

idobata用として絵文字を使いまくったのでコンソールで実行するとすごく微妙です。

あまりテストができてない (たとえば日付などのデータがないときにDoorkeeperがどういうJSONを返すかわかってない) ので、もしかしたらそういった状況次第では将来エラーが出るかもしれません。
